### PR TITLE
Enable parsing of `&&` as two separate tokens in types

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -344,3 +344,33 @@ func (l *Lexer) Expect(kinds ...token.Kind) token.Token {
 
 	panic("unreachable")
 }
+
+// In expressions, && is a single token. In a type, however it is 2 tokens.
+// Same goes for >> (for generic types)
+//
+// Since this lexer is LL(1) a simple workaround is to "split" the token and
+// buffer the right part. The left part gets returned
+func (l *Lexer) SplitAndBufferRight(tok token.Token) token.Token {
+	switch tok.Kind {
+	case token.LAnd:
+		tok.Kind = token.BAnd
+		tok.Str = "&"
+		lhs := tok
+
+		tok.Pos.Col++
+		l.Buffer(tok)
+		return lhs
+
+	case token.Shr:
+		tok.Kind = token.Gt
+		tok.Str = ">"
+		lhs := tok
+
+		tok.Pos.Col++
+		l.Buffer(tok)
+		return lhs
+
+	default:
+		panic("unreachable")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -73,6 +73,10 @@ func (p *Parser) parseType() node.Node {
 			Token: tok,
 		}
 
+	case token.LAnd:
+		tok = p.lexer.SplitAndBufferRight(tok)
+		fallthrough
+
 	case token.BAnd:
 		return &node.Unary{
 			Token:   tok,

--- a/tests/pointers/multiple-level-type-parse.yo
+++ b/tests/pointers/multiple-level-type-parse.yo
@@ -1,0 +1,9 @@
+fn main() {
+    let x i64 = 69
+    let y &i64 = &x
+    let z &&i64 = &y
+
+    print x
+    **z = 420
+    print x
+}

--- a/tests/test.list
+++ b/tests/test.list
@@ -23,6 +23,7 @@ local-variables/error-assignment-does-not-match-type-in-definition.yo
 local-variables/error-cannot-define-with-unit-type.yo
 pointers/reference-dereference.yo
 pointers/reference-dereference-multiple.yo
+pointers/multiple-level-type-parse.yo
 pointers/error-dereference-expected-pointer.yo
 pointers/error-reference-not-memory.yo
 functions/no-arguments-no-return.yo

--- a/tests/test.list.bi
+++ b/tests/test.list.bi
@@ -1,4 +1,4 @@
-:i count 46
+:i count 47
 :b testcase 14
 arithmetics.yo
 :i returncode 0
@@ -281,6 +281,15 @@ pointers/reference-dereference-multiple.yo
 69
 420
 1337
+
+:b stderr 0
+
+:b testcase 37
+pointers/multiple-level-type-parse.yo
+:i returncode 0
+:b stdout 7
+69
+420
 
 :b stderr 0
 


### PR DESCRIPTION
Also for >>